### PR TITLE
Section requires text attribute if no fields attribute is provided

### DIFF
--- a/src/Block/Section.php
+++ b/src/Block/Section.php
@@ -6,6 +6,7 @@ use Maknz\Slack\Block;
 use Maknz\Slack\BlockElement;
 use Maknz\Slack\BlockElement\Text;
 use Maknz\Slack\FieldsTrait;
+use UnexpectedValueException;
 
 class Section extends Block
 {
@@ -143,15 +144,20 @@ class Section extends Block
     {
         $data = [
             'type' => $this->getType(),
-            'text' => $this->getText()->toArray(),
         ];
 
-        if ($this->getBlockId()) {
-            $data['block_id'] = $this->getBlockId();
+        if ($this->getText()) {
+            $data['text'] = $this->getText()->toArray();
         }
 
         if (count($this->getFields())) {
             $data['fields'] = $this->getFieldsAsArrays();
+        } elseif (!$this->getText()) {
+            throw new UnexpectedValueException('Section requires text attribute if no fields attribute is provided');
+        }
+
+        if ($this->getBlockId()) {
+            $data['block_id'] = $this->getBlockId();
         }
 
         if ($this->getAccessory()) {

--- a/src/Block/Section.php
+++ b/src/Block/Section.php
@@ -152,7 +152,7 @@ class Section extends Block
 
         if (count($this->getFields())) {
             $data['fields'] = $this->getFieldsAsArrays();
-        } elseif (!$this->getText()) {
+        } elseif ( ! $this->getText()) {
             throw new UnexpectedValueException('Section requires text attribute if no fields attribute is provided');
         }
 

--- a/tests/Block/SectionUnitTest.php
+++ b/tests/Block/SectionUnitTest.php
@@ -5,6 +5,7 @@ use InvalidArgumentException;
 use Maknz\Slack\Block\Section;
 use Maknz\Slack\BlockElement\Text;
 use Slack\Tests\TestCase;
+use UnexpectedValueException;
 
 class SectionUnitTest extends TestCase
 {
@@ -166,5 +167,60 @@ class SectionUnitTest extends TestCase
         $s = new Section($in);
 
         $this->assertEquals($out, $s->toArray());
+    }
+
+    /**
+     * Text field becomes optional when fields are provided.
+     *
+     * @throws \InvalidArgumentException
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testSectionToArrayWithNoText()
+    {
+        $s = new Section([
+            'fields' => [
+                [
+                    'type' => Text::TYPE_PLAIN,
+                    'text' => 'Text 1',
+                ],
+                [
+                    'type' => Text::TYPE_MARKDOWN,
+                    'text' => 'Text 2',
+                ],
+            ],
+        ]);
+
+        $out = [
+            'type'   => 'section',
+            'fields' => [
+                [
+                    'type'     => Text::TYPE_PLAIN,
+                    'text'     => 'Text 1',
+                    'emoji'    => false,
+                ],
+                [
+                    'type'     => Text::TYPE_MARKDOWN,
+                    'text'     => 'Text 2',
+                    'verbatim' => false,
+                ],
+            ],
+        ];
+
+        $this->assertEquals($out, $s->toArray());
+    }
+
+    /**
+     * @throws \UnexpectedValueException
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     */
+    public function testSectionMissingText()
+    {
+        $s = new Section([]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Section requires text attribute if no fields attribute is provided');
+        $s->toArray();
     }
 }


### PR DESCRIPTION
Fixes #48.

Uses `UnexpectedValueException` (a runtime exception) instead of `InvalidArgumentException` as it is thrown when the block is serialised.