### PR TITLE
Added callback_id to Attachment.php

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -78,6 +78,13 @@ class Attachment extends Payload
     protected $author_icon;
 
     /**
+     * Optional provide callback_id used to provide interactivity callback information on the request.
+     *
+     * @var string
+     */
+    protected $callback_id;
+
+    /**
      * The color to use for the attachment.
      *
      * @var string
@@ -143,6 +150,7 @@ class Attachment extends Payload
         'author_name' => 'author_name',
         'author_link' => 'author_link',
         'author_icon' => 'author_icon',
+        'callback_id' => 'callback_id',
         'actions'     => 'actions',
     ];
 
@@ -490,6 +498,30 @@ class Attachment extends Payload
     }
 
     /**
+     * Get the callback id for use with interactivity.
+     *
+     * @return string
+     */
+    public function getCallbackId()
+    {
+        return $this->callback_id;
+    }
+
+    /**
+     * Set the callback id to use with interactivity.
+     *
+     * @param string $callback_id
+     *
+     * @return $this
+     */
+    public function setCallbackId($callback_id)
+    {
+        $this->callback_id = $callback_id;
+
+        return $this;
+    }
+
+    /**
      * Clear the actions for the attachment.
      *
      * @return $this
@@ -604,6 +636,7 @@ class Attachment extends Payload
             'author_name' => $this->getAuthorName(),
             'author_link' => $this->getAuthorLink(),
             'author_icon' => $this->getAuthorIcon(),
+            'callback_id' => $this->getCallbackId(),
         ];
 
         $data['fields'] = $this->getFieldsAsArrays();

--- a/tests/AttachmentUnitTest.php
+++ b/tests/AttachmentUnitTest.php
@@ -26,6 +26,7 @@ class AttachmentUnitTest extends TestCase
             'footer_icon' => 'https://platform.slack-edge.com/img/default_application_icon.png',
             'timestamp' => $now,
             'mrkdwn_in' => ['pretext', 'text', 'fields'],
+            'callback_id' => 'callback',
         ]);
 
         $this->assertEquals('Fallback', $a->getFallback());
@@ -45,6 +46,8 @@ class AttachmentUnitTest extends TestCase
         $this->assertEquals('https://platform.slack-edge.com/img/default_application_icon.png', $a->getFooterIcon());
 
         $this->assertEquals($now, $a->getTimestamp());
+
+        $this->assertEquals('callback', $a->getCallbackId());
     }
 
     /**
@@ -105,6 +108,7 @@ class AttachmentUnitTest extends TestCase
             'author_name' => 'Joe Bloggs',
             'author_link' => 'http://fake.host/',
             'author_icon' => 'http://fake.host/image.png',
+            'callback_id' => 'callback',
             'fields' => [
                 [
                     'title' => 'Title 1',
@@ -165,6 +169,7 @@ class AttachmentUnitTest extends TestCase
             'author_name' => 'Joe Bloggs',
             'author_link' => 'http://fake.host/',
             'author_icon' => 'http://fake.host/image.png',
+            'callback_id' => 'callback',
             'fields' => [
                 [
                     'title' => 'Title 1',

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -67,6 +67,7 @@ class ClientFunctionalTest extends TestCase
             'author_link' => 'http://fake.host/',
             'author_icon' => 'http://fake.host/image.png',
             'actions' => [],
+            'callback_id' => 'callback',
         ];
 
         $client = new Client('http://fake.endpoint', [
@@ -101,6 +102,7 @@ class ClientFunctionalTest extends TestCase
             'author_link' => 'http://fake.host/',
             'author_icon' => 'http://fake.host/image.png',
             'actions' => [],
+            'callback_id' => 'callback',
         ];
 
         $expectedHttpData = [
@@ -144,6 +146,7 @@ class ClientFunctionalTest extends TestCase
             'author_name' => 'Joe Bloggs',
             'author_link' => 'http://fake.host/',
             'author_icon' => 'http://fake.host/image.png',
+            'callback_id' => 'callback',
             'fields' => [
                 [
                     'title' => 'Field 1',
@@ -175,6 +178,7 @@ class ClientFunctionalTest extends TestCase
             'author_name' => 'Joe Bloggs',
             'author_link' => 'http://fake.host/',
             'author_icon' => 'http://fake.host/image.png',
+            'callback_id' => 'callback',
             'fields' => [
                 [
                     'title' => 'Field 1',
@@ -244,6 +248,7 @@ class ClientFunctionalTest extends TestCase
             'author_name' => 'Joe Bloggs',
             'author_link' => 'http://fake.host/',
             'author_icon' => 'http://fake.host/image.png',
+            'callback_id' => 'callback',
             'fields' => [],
             'actions' => [
                 [
@@ -293,6 +298,7 @@ class ClientFunctionalTest extends TestCase
             'author_name' => 'Joe Bloggs',
             'author_link' => 'http://fake.host/',
             'author_icon' => 'http://fake.host/image.png',
+            'callback_id' => 'callback',
             'fields' => [],
             'actions' => [
                 [


### PR DESCRIPTION
Added callback_id to Attachment.php to allow for working with the interactivity callback api in slack. Without this, Slack will not call back to your API web hook.