### PR TITLE
Update Composer and PHPUnit to PHP 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 .DS_Store
 /phpunit.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
+  - 8.0
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": "^7.1|^8.0",
         "guzzlehttp/guzzle": "~7.0|~6.0|~5.0|~4.0",
         "ext-mbstring": "*",
         "ext-json": "*"

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.1",
         "guzzlehttp/guzzle": "~7.0|~6.0|~5.0|~4.0",
         "ext-mbstring": "*",
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": ">=7.5",
         "mockery/mockery": "^1.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <testsuites>
-    <testsuite name="Package Test Suite">
-      <directory suffix=".php">./tests/</directory>
-    </testsuite>
-  </testsuites>
-  <filter>
-    <whitelist>
-      <directory>./</directory>
-      <exclude>
-        <directory>./tests</directory>
-        <directory>./vendor</directory>
-      </exclude>
-    </whitelist>
-  </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+>
+    <testsuites>
+        <testsuite name="Package Test Suite">
+            <directory suffix=".php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,4 +5,13 @@
       <directory suffix=".php">./tests/</directory>
     </testsuite>
   </testsuites>
+  <filter>
+    <whitelist>
+      <directory>./</directory>
+      <exclude>
+        <directory>./tests</directory>
+        <directory>./vendor</directory>
+      </exclude>
+    </whitelist>
+  </filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <testsuites>
+    <testsuite name="Package Test Suite">
+      <directory suffix=".php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/Block/ActionsUnitTest.php
+++ b/tests/Block/ActionsUnitTest.php
@@ -44,7 +44,7 @@ class ActionsUnitTest extends TestCase
     public function testInvalidElement()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Block element .+ is not valid/');
+        $this->expectExceptionMessage('Block element Maknz\Slack\BlockElement\MultiSelect is not valid');
         $a = new Actions([
             'elements' => [[
                 'type' => 'multi_static_select',

--- a/tests/Block/ContextUnitTest.php
+++ b/tests/Block/ContextUnitTest.php
@@ -38,7 +38,7 @@ class ContextUnitTest extends TestCase
     public function testInvalidElement()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Block element .+ is not valid/');
+        $this->expectExceptionMessage('Block element Maknz\Slack\BlockElement\MultiSelect is not valid');
         $c = new Context([
             'elements' => [[
                 'type' => 'multi_static_select',

--- a/tests/Block/InputUnitTest.php
+++ b/tests/Block/InputUnitTest.php
@@ -34,7 +34,7 @@ class InputUnitTest extends TestCase
     public function testInvalidElement()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Block element .+ is not valid/');
+        $this->expectExceptionMessage('Block element Maknz\Slack\BlockElement\Button is not valid');
         $i = new Input([
             'element' => [
                 'type' => 'button',

--- a/tests/BlockElementUnitTest.php
+++ b/tests/BlockElementUnitTest.php
@@ -26,7 +26,7 @@ class BlockElementUnitTest extends TestCase
     public function testFactoryInvalidType()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Invalid Block type "invalid"/');
+        $this->expectExceptionMessage('Invalid Block type "invalid"');
         $element = BlockElement::factory([
             'type' => 'invalid',
         ]);

--- a/tests/BlockUnitTest.php
+++ b/tests/BlockUnitTest.php
@@ -26,7 +26,7 @@ class BlockUnitTest extends TestCase
     public function testFactoryInvalidType()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Block type must be one of/');
+        $this->expectExceptionMessage('Block type must be one of');
         $element = Block::factory([
             'type' => 'invalid',
         ]);


### PR DESCRIPTION
PHP 8.0 shipped today, and Composer and PHPUnit prevents this package from upgrading to PHP 8.0

 * Updated the unit tests to be compatible with PHPUnit 9.4
 * Added PHP 7.4 and 8.0 to Travis CI, but PHP 8.0 is not yet supported
 * Updated composer.json to be compatible with PHP 8.0
 * Confirmed unit tests work with PHP 7.1 and higher