### PR TITLE
Change fieldClass property to trait abstract

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -155,11 +155,14 @@ class Attachment extends Payload
     ];
 
     /**
-     * Class name of valid fields.
+     * Get the class name of valid fields.
      *
-     * @var string
+     * @return string
      */
-    protected static $fieldClass = AttachmentField::class;
+    protected function getFieldClass()
+    {
+        return AttachmentField::class;
+    }
 
     /**
      * Get the fallback text.

--- a/src/Block/Section.php
+++ b/src/Block/Section.php
@@ -53,11 +53,14 @@ class Section extends Block
     ];
 
     /**
-     * Class name of valid fields.
+     * Get the class name of valid fields.
      *
-     * @var string
+     * @return string
      */
-    protected static $fieldClass = Text::class;
+    protected function getFieldClass()
+    {
+        return Text::class;
+    }
 
     /**
      * Get the section text.
@@ -96,7 +99,7 @@ class Section extends Block
      */
     public function addField($field)
     {
-        $field = static::$fieldClass::create($field);
+        $field = $this->getFieldClass()::create($field);
 
         $this->fields[] = $field;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -430,7 +430,7 @@ class Client
      */
     public function createMessage()
     {
-        $message = new Message($this);
+        $message = new Message();
 
         $message->setChannel($this->getDefaultChannel());
 

--- a/src/FieldsTrait.php
+++ b/src/FieldsTrait.php
@@ -13,6 +13,13 @@ trait FieldsTrait
     protected $fields = [];
 
     /**
+     * Get the class name of valid fields.
+     *
+     * @return string
+     */
+    abstract protected function getFieldClass();
+
+    /**
      * Get the fields for the block/attachment.
      *
      * @return \Maknz\Slack\Field[]|array
@@ -53,17 +60,19 @@ trait FieldsTrait
      */
     public function addField($field)
     {
-        if ($field instanceof static::$fieldClass) {
+        $fieldClass = $this->getFieldClass();
+
+        if ($field instanceof $fieldClass) {
             $this->fields[] = $field;
 
             return $this;
         } elseif (is_array($field)) {
-            $this->fields[] = new static::$fieldClass($field);
+            $this->fields[] = new $fieldClass($field);
 
             return $this;
         }
 
-        throw new InvalidArgumentException('The field must be an instance of '.static::$fieldClass.' or a keyed array');
+        throw new InvalidArgumentException('The field must be an instance of '.$fieldClass.' or a keyed array');
     }
 
     /**

--- a/tests/FieldsTraitUnitTest.php
+++ b/tests/FieldsTraitUnitTest.php
@@ -131,7 +131,11 @@ class FieldsTraitUnitTest extends TestCase
 class FieldsMock
 {
     use FieldsTrait;
-    protected static $fieldClass = AttachmentField::class;
+
+    protected function getFieldClass()
+    {
+        return AttachmentField::class;
+    }
 
     public function mockGetFieldsAsArrays()
     {


### PR DESCRIPTION
Fixes a [Scrutinizer bug](https://scrutinizer-ci.com/g/php-slack/slack/issues/master?selectedSeverities[]=10) by using an abstract method on FieldsTrait to get the class name for field members, rather than relying on the presence of a property which can't be nicely enforced.