### PR TITLE
autoload-dev for tests directory to keep it out of production autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,11 @@
     },
     "autoload": {
         "psr-4": {
-            "Maknz\\Slack\\": "src/",
+            "Maknz\\Slack\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Slack\\Tests\\": "tests/"
         }
     },


### PR DESCRIPTION
Composer 2 has autoload-dev (maybe 1.0 had it too, not sure), so we should use it to keep test directory out of production autoloaders.